### PR TITLE
Hofix_MAPF_1

### DIFF
--- a/src/GiD_Problemtype/Anura3D_2025.gid/Anura3D_2025.tcl
+++ b/src/GiD_Problemtype/Anura3D_2025.gid/Anura3D_2025.tcl
@@ -653,9 +653,10 @@ proc Anura3D::anura3D_WriteBatchFile { filebatch icount_stage cps_extension gom_
     GiD_WriteCalculationFile puts "if exist %4\\%1.$cps_extension del %4\\%1.$cps_extension"
     GiD_WriteCalculationFile puts "copy %2\\%1.$cps_extension %4\\%1.$cps_extension"
     GiD_WriteCalculationFile puts "copy %2\\%1-2.dat %2\\%1.$gom_extension"
-    GiD_WriteCalculationFile puts "if exist %4\\%1.$gom_extension del %4\\%1.$gom_extension"    
-    GiD_WriteCalculationFile puts "copy %2\\%1.$gom_extension %4\\%1.$gom_extension"      
-    GiD_WriteCalculationFile end           
+    GiD_WriteCalculationFile puts "if exist %4\\%1.$gom_extension del %4\\%1.$gom_extension"      
+    GiD_WriteCalculationFile puts "copy %2\\%1.$gom_extension %4\\%1.$gom_extension"
+    GiD_WriteCalculationFile puts "if exist %2\\%1.MAPF copy %2\\%1.MAPF %4\\%1.MAPF"
+    GiD_WriteCalculationFile end	
 }
 
 proc Anura3D::LoadScripts { } {

--- a/src/ReadCalculationData.FOR
+++ b/src/ReadCalculationData.FOR
@@ -2736,7 +2736,11 @@ subroutine ReadPrescribedAccelerationOrVelocityFromFile()
 
         ! Prepare file name for opening
         FileName = trim(CalParams%FileNames%ProjectName)//MPMAPFROMEXT_FILE_EXTENSION !
-        if (FExist(FileName)) call FileOpen(MAPUnit,trim(FileName))
+        if (.not.FExist(FileName)) then
+            call GiveError('Mapping file not found: ' // trim(FileName) // &
+                '. Stress initialization from external file requires a .MAPF file.')
+        end if
+        call FileOpen(MAPUnit,trim(FileName))
 
         ! Read each line
         NumberOfLines = 0


### PR DESCRIPTION
Fixed bug in the map stresses from file feature. ".MAPF" file was not copied to the A3D folder from the .gid project folder. A warning message is added in case no .MAPF file exists on the -gid folder.